### PR TITLE
feat: add GitHub-style contribution graph for bookmark activity

### DIFF
--- a/app/assets/stylesheets/contribution_graph.scss
+++ b/app/assets/stylesheets/contribution_graph.scss
@@ -1,0 +1,90 @@
+.contribution-graph {
+  .contribution-grid {
+    display: flex;
+    gap: 2px;
+    overflow-x: auto;
+    padding: 4px 0;
+  }
+  
+  .contribution-week {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  
+  .contribution-day {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background-color: var(--bs-gray-800);
+    border: 1px solid var(--bs-gray-700);
+    cursor: pointer;
+    transition: all 0.1s ease-in-out;
+    
+    &:hover {
+      border-color: var(--bs-gray-500);
+    }
+    
+    // Activity levels with green shades for dark theme
+    &.level-0 {
+      background-color: var(--bs-gray-800);
+    }
+    
+    &.level-1 {
+      background-color: #0d4429;
+    }
+    
+    &.level-2 {
+      background-color: #006d32;
+    }
+    
+    &.level-3 {
+      background-color: #26a641;
+    }
+    
+    &.level-4 {
+      background-color: #39d353;
+    }
+  }
+  
+  .contribution-legend {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    color: var(--bs-gray-400);
+    
+    .legend-squares {
+      display: flex;
+      gap: 2px;
+      
+      .contribution-day {
+        width: 8px;
+        height: 8px;
+      }
+    }
+    
+    .legend-text {
+      font-size: 0.75rem;
+    }
+  }
+}
+
+// Responsive positioning
+@media (max-width: 1199.98px) {
+  .contribution-graph-mobile {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+    
+    .contribution-grid {
+      justify-content: center;
+    }
+  }
+}
+
+@media (min-width: 1200px) {
+  .contribution-graph-desktop {
+    position: sticky;
+    top: 1rem;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,41 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def contribution_graph_data(weeks: 53)
+    end_date = Date.current
+    start_date = end_date - (weeks * 7).days
+    
+    # Get all bookmarks created in the date range, grouped by date
+    bookmark_counts = Bookmark
+      .where(created_at: start_date.beginning_of_day..end_date.end_of_day)
+      .group("DATE(created_at)")
+      .count
+    
+    # Generate array of dates with their counts
+    (start_date..end_date).map do |date|
+      count = bookmark_counts[date] || 0
+      {
+        date: date,
+        count: count,
+        level: contribution_level(count)
+      }
+    end
+  end
+  
+  private
+  
+  def contribution_level(count)
+    case count
+    when 0
+      0
+    when 1..2
+      1
+    when 3..5
+      2
+    when 6..10
+      3
+    else
+      4
+    end
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,6 +8,9 @@
     <%= render "shared/bookmarks", bookmarks: @bookmarks %>
   </div>
   <div class="col-xl-2 mb-5 mb-xl-0">
+    <div class="contribution-graph-desktop d-none d-xl-block mb-4">
+      <%= render "shared/contribution_graph" %>
+    </div>
     <div class="d-flex align-items-end mb-3">
       <h2 class="h1 mb-0 me-3">タグ</h2>
       (<%= link_to "タグを作成", new_tag_path %>)
@@ -20,4 +23,9 @@
       <% end %>
     </div>
   </div>
+</div>
+
+<!-- Mobile contribution graph -->
+<div class="contribution-graph-mobile d-block d-xl-none">
+  <%= render "shared/contribution_graph" %>
 </div>

--- a/app/views/shared/_contribution_graph.html.erb
+++ b/app/views/shared/_contribution_graph.html.erb
@@ -1,0 +1,62 @@
+<div class="contribution-graph">
+  <h3 class="h6 mb-3">投稿アクティビティ</h3>
+  
+  <div class="contribution-grid">
+    <% contribution_data = contribution_graph_data %>
+    <% 
+      # Group data by week, starting from Sunday
+      weeks = []
+      current_week = []
+      start_date = contribution_data.first[:date]
+      
+      # Pad the first week if it doesn't start on Sunday
+      (start_date.wday).times do
+        current_week << nil
+      end
+      
+      contribution_data.each do |day_data|
+        current_week << day_data
+        
+        if current_week.length == 7
+          weeks << current_week
+          current_week = []
+        end
+      end
+      
+      # Pad the last week if needed
+      while current_week.length < 7 && current_week.any?
+        current_week << nil
+      end
+      
+      weeks << current_week if current_week.any?
+    %>
+    
+    <% weeks.each do |week| %>
+      <div class="contribution-week">
+        <% week.each do |day_data| %>
+          <% if day_data %>
+            <div class="contribution-day level-<%= day_data[:level] %>" 
+                 title="<%= day_data[:date].strftime('%Y年%m月%d日') %>: <%= day_data[:count] %>件の投稿"
+                 data-date="<%= day_data[:date].iso8601 %>"
+                 data-count="<%= day_data[:count] %>">
+            </div>
+          <% else %>
+            <div class="contribution-day level-0"></div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  
+  <div class="contribution-legend mt-2">
+    <span class="legend-text">少ない</span>
+    <div class="legend-squares">
+      <div class="contribution-day level-0"></div>
+      <div class="contribution-day level-1"></div>
+      <div class="contribution-day level-2"></div>
+      <div class="contribution-day level-3"></div>
+      <div class="contribution-day level-4"></div>
+    </div>
+    <span class="legend-text">多い</span>
+  </div>
+</div>


### PR DESCRIPTION
Add GitHub-style contribution graph that displays daily bookmark posting activity with color intensity based on volume.

**Features:**
- Responsive positioning: right sidebar on desktop, bottom on mobile
- 53 weeks of activity history
- 5 activity levels with GitHub-style green squares
- Japanese tooltips with date and bookmark count
- Dark theme compatible styling

Closes #33

Generated with [Claude Code](https://claude.ai/code)